### PR TITLE
Added endpoints to search Materials

### DIFF
--- a/src/main/kotlin/org/cdb/homunculus/controller/BoxController.kt
+++ b/src/main/kotlin/org/cdb/homunculus/controller/BoxController.kt
@@ -42,6 +42,11 @@ fun Routing.boxController() =
 			call.respond(boxLogic.getByPosition(HierarchicalId(shelfId)))
 		}
 
+		authenticatedGet("/byBatchNumber") {
+			val query = requireNotNull(call.request.queryParameters["query"]) { "query must not be null." }
+			call.respond(boxLogic.findByBatchNumber(query))
+		}
+
 		authenticatedPost("", permissions = setOf(Permissions.MANAGE_MATERIALS)) {
 			val boxToCreate = call.receive<Box>()
 			call.respond(boxLogic.create(boxToCreate, it.userId))

--- a/src/main/kotlin/org/cdb/homunculus/controller/TagController.kt
+++ b/src/main/kotlin/org/cdb/homunculus/controller/TagController.kt
@@ -26,6 +26,12 @@ fun Routing.tagController() =
 			call.respond(tagLogic.get(EntityId(tagId)))
 		}
 
+		authenticatedPost("/byIds") {
+			val tagIds = call.receive<Set<EntityId>>()
+			require(tagIds.isNotEmpty()) { "Tag Ids must not be null or empty" }
+			call.respond(tagLogic.getByIds(tagIds))
+		}
+
 		authenticatedPost("", permissions = setOf(Permissions.MANAGE_METADATA)) {
 			val tagToCreate = call.receive<Tag>()
 			call.respond(tagLogic.create(tagToCreate))

--- a/src/main/kotlin/org/cdb/homunculus/dao/BoxDao.kt
+++ b/src/main/kotlin/org/cdb/homunculus/dao/BoxDao.kt
@@ -13,23 +13,38 @@ abstract class BoxDao(client: DBClient) : GenericDao<Box>(client) {
 	override fun wrapIdentifier(id: String): EntityId = EntityId(id)
 
 	/**
-	 * Retrieves all the boxes with the specified [materialId].
+	 * Retrieves all the boxes with the specified [Box.material].
 	 *
 	 * @param materialId the [EntityId] of the material
+	 * @param includeDeleted whether to include the Boxes where [Box.deletionDate] is not null.
 	 * @return a [Flow] of [Box]es.
 	 */
-	abstract fun getByMaterial(materialId: EntityId): Flow<Box>
+	abstract fun getByMaterial(
+		materialId: EntityId,
+		includeDeleted: Boolean,
+	): Flow<Box>
+
+	/**
+	 * Retrieves all the [Box]es where [Box.batchNumber] is not null and starts with [query].
+	 *
+	 * @param query the prefix for [Box.batchNumber] to search for.
+	 * @param includeDeleted whether to include the Boxes where [Box.deletionDate] is not null.
+	 * @return a [Flow] of [Box] that match the condition.
+	 */
+	abstract fun getByBatchNumber(
+		query: String,
+		includeDeleted: Boolean,
+	): Flow<Box>
 
 	/**
 	 * Retrieves all the boxes in a specified shelf.
 	 *
 	 * @param shelfId the id of the shelf.
+	 * @param includeDeleted whether to include the Boxes where [Box.deletionDate] is not null.
 	 * @return a [Flow] of [Box]es.
 	 */
-	abstract fun getByPosition(shelfId: HierarchicalId): Flow<Box>
-
-	/**
-	 * @return a [Flow] containing all the [Box]es in the database.
-	 */
-	abstract fun getAll(): Flow<Box>
+	abstract fun getByPosition(
+		shelfId: HierarchicalId,
+		includeDeleted: Boolean,
+	): Flow<Box>
 }

--- a/src/main/kotlin/org/cdb/homunculus/dao/GenericDao.kt
+++ b/src/main/kotlin/org/cdb/homunculus/dao/GenericDao.kt
@@ -41,6 +41,14 @@ abstract class GenericDao<T : StoredEntity>(
 	suspend fun getById(id: Identifier): T? = collection.find(Filters.eq("_id", id.id)).firstOrNull()
 
 	/**
+	 * Retrieves multiple [T]s by id.
+	 *
+	 * @param ids a [Set] containing the [Identifier]s of the elements to retrieve. Non-existing ids are ignored..
+	 * @return a [Flow] of [T] which id is contained in [ids].
+	 */
+	fun getByIds(ids: Set<Identifier>): Flow<T> = collection.find(Filters.`in`("_id", ids.map { it.id }))
+
+	/**
 	 * Retrieves all the entities matching the specified filter.
 	 *
 	 * @param filter a [Bson] filter.

--- a/src/main/kotlin/org/cdb/homunculus/dao/MaterialDao.kt
+++ b/src/main/kotlin/org/cdb/homunculus/dao/MaterialDao.kt
@@ -3,6 +3,7 @@ package org.cdb.homunculus.dao
 import com.mongodb.kotlin.client.coroutine.MongoCollection
 import kotlinx.coroutines.flow.Flow
 import org.cdb.homunculus.components.DBClient
+import org.cdb.homunculus.models.Box
 import org.cdb.homunculus.models.Material
 import org.cdb.homunculus.models.identifiers.EntityId
 
@@ -15,11 +16,49 @@ abstract class MaterialDao(client: DBClient) : GenericDao<Material>(client) {
 	 * Retrieves all the [Material]s where [Material.normalizedName] is not null and starts with [query].
 	 *
 	 * @param query the prefix for [Material.normalizedName] to search for.
+	 * @param includeDeleted whether to include the Boxes where [Box.deletionDate] is not null.
 	 * @param limit the maximum number of elements to return. If null, all the elements will be returned.
 	 * @return a [Flow] of [Material] that match the condition.
 	 */
-	abstract fun byFuzzyName(
+	abstract fun getByFuzzyName(
 		query: String,
+		includeDeleted: Boolean,
+		limit: Int?,
+	): Flow<Material>
+
+	/**
+	 * Retrieves the last [limit] [Material]s in descending order by [Material.creationDate].
+	 *
+	 * @param limit the number of elements to retrieve.
+	 * @return a [Flow] of [Material].
+	 */
+	abstract fun getLastCreated(limit: Int): Flow<Material>
+
+	/**
+	 * Retrieves all the [Material]s where [Material.referenceCode] is not null and starts with [query].
+	 *
+	 * @param query the prefix for [Material.referenceCode] to search for.
+	 * @param includeDeleted whether to include the Boxes where [Box.deletionDate] is not null.
+	 * @param limit the maximum number of elements to return. If null, all the elements will be returned.
+	 * @return a [Flow] of [Material] that match the condition.
+	 */
+	abstract fun getByReferenceCode(
+		query: String,
+		includeDeleted: Boolean,
+		limit: Int?,
+	): Flow<Material>
+
+	/**
+	 * Retrieves all the [Material]s where [Material.brand] starts with [query].
+	 *
+	 * @param query the prefix for [Material.brand] to search for.
+	 * @param includeDeleted whether to include the Boxes where [Box.deletionDate] is not null.
+	 * @param limit the maximum number of elements to return. If null, all the elements will be returned.
+	 * @return a [Flow] of [Material] that match the condition.
+	 */
+	abstract fun getByBrand(
+		query: String,
+		includeDeleted: Boolean,
 		limit: Int?,
 	): Flow<Material>
 }

--- a/src/main/kotlin/org/cdb/homunculus/dao/impl/MaterialDaoImpl.kt
+++ b/src/main/kotlin/org/cdb/homunculus/dao/impl/MaterialDaoImpl.kt
@@ -1,21 +1,65 @@
 package org.cdb.homunculus.dao.impl
 
 import com.mongodb.client.model.Filters
+import com.mongodb.client.model.Sorts
 import kotlinx.coroutines.flow.Flow
 import org.cdb.homunculus.annotations.Index
 import org.cdb.homunculus.components.DBClient
 import org.cdb.homunculus.dao.MaterialDao
+import org.cdb.homunculus.models.Box
 import org.cdb.homunculus.models.Material
+import org.cdb.homunculus.utils.StringNormalizer
 import org.cdb.homunculus.utils.limit
 import java.util.regex.Pattern
 
 class MaterialDaoImpl(client: DBClient) : MaterialDao(client) {
 	@Index(name = "by_fuzzy_name", property = "normalizedName", unique = false)
-	override fun byFuzzyName(
+	override fun getByFuzzyName(
 		query: String,
+		includeDeleted: Boolean,
 		limit: Int?,
 	): Flow<Material> =
 		collection.find(
-			Filters.regex(Material::normalizedName.name, Pattern.compile("^$query.*")),
+			Filters.and(
+				listOfNotNull(
+					Filters.regex(Material::normalizedName.name, Pattern.compile("^${StringNormalizer.normalize(query)}.*")),
+					Filters.exists(Box::deletionDate.name, false).takeIf { !includeDeleted },
+				),
+			),
+		).limit(limit)
+
+	override fun getLastCreated(limit: Int): Flow<Material> =
+		collection.find()
+			.sort(Sorts.descending(Material::creationDate.name))
+			.limit(limit)
+
+	@Index(name = "by_reference_code", property = "referenceCode", unique = false)
+	override fun getByReferenceCode(
+		query: String,
+		includeDeleted: Boolean,
+		limit: Int?,
+	): Flow<Material> =
+		collection.find(
+			Filters.and(
+				listOfNotNull(
+					Filters.regex(Material::referenceCode.name, Pattern.compile("^${query.lowercase()}.*", Pattern.CASE_INSENSITIVE)),
+					Filters.exists(Box::deletionDate.name, false).takeIf { !includeDeleted },
+				),
+			),
+		).limit(limit)
+
+	@Index(name = "by_brand", property = "brand", unique = false)
+	override fun getByBrand(
+		query: String,
+		includeDeleted: Boolean,
+		limit: Int?,
+	): Flow<Material> =
+		collection.find(
+			Filters.and(
+				listOfNotNull(
+					Filters.regex(Material::brand.name, Pattern.compile("^${query.lowercase()}.*", Pattern.CASE_INSENSITIVE)),
+					Filters.exists(Box::deletionDate.name, false).takeIf { !includeDeleted },
+				),
+			),
 		).limit(limit)
 }

--- a/src/main/kotlin/org/cdb/homunculus/logic/BoxLogic.kt
+++ b/src/main/kotlin/org/cdb/homunculus/logic/BoxLogic.kt
@@ -87,4 +87,13 @@ interface BoxLogic {
 	 * @throws NotFoundException if there is no user with such an id in the system.
 	 */
 	suspend fun modify(box: Box)
+
+	/**
+	 * Retrieves all the [Box]es based on a match between the normalized [query] and [Box.batchNumber], excluding the ones
+	 * where [Box.deletionDate] is set.
+	 *
+	 * @param query the query, to be normalized.
+	 * @return a [Flow] of [Box]es.
+	 */
+	fun findByBatchNumber(query: String): Flow<Box>
 }

--- a/src/main/kotlin/org/cdb/homunculus/logic/MaterialLogic.kt
+++ b/src/main/kotlin/org/cdb/homunculus/logic/MaterialLogic.kt
@@ -63,4 +63,34 @@ interface MaterialLogic {
 	 * @throws NotFoundException if there is no user with such an id in the system.
 	 */
 	suspend fun modify(material: Material)
+
+	/**
+	 * Retrieves the [EntityId]s of all the [Material] where [Material.normalizedName], [Material.brand], or [Material.referenceCode] start
+	 * with the provided [query].
+	 * If one or more [tagIds] are specified, then only the Materials with the specified [Material.tags] are considered.
+	 *
+	 * @param query the prefix for the properties to search.
+	 * @param tagIds the ids of the tags that a [Material] must have to be included in the results.
+	 * @return a [Set] of the [EntityId]s of the matching [Material]s.
+	 */
+	suspend fun search(
+		query: String,
+		tagIds: Set<EntityId>?,
+	): Set<EntityId>
+
+	/**
+	 * Retrieves multiple [Material]s by their [Material.id].
+	 *
+	 * @param ids the ids of the [Material]s to retrieve. All the ids that do not correspond to an actual material are ignored.
+	 * @return a [Flow] of [Material]s.
+	 */
+	fun getByIds(ids: Set<EntityId>): Flow<Material>
+
+	/**
+	 * Retrieves the last [limit] [Material]s in descending order by [Material.creationDate].
+	 *
+	 * @param limit the number of elements to retrieve.
+	 * @return a [Flow] of [Material].
+	 */
+	fun getLastCreated(limit: Int): Flow<Material>
 }

--- a/src/main/kotlin/org/cdb/homunculus/logic/TagLogic.kt
+++ b/src/main/kotlin/org/cdb/homunculus/logic/TagLogic.kt
@@ -1,6 +1,7 @@
 package org.cdb.homunculus.logic
 
 import kotlinx.coroutines.flow.Flow
+import org.cdb.homunculus.exceptions.NotFoundException
 import org.cdb.homunculus.models.embed.Tag
 import org.cdb.homunculus.models.identifiers.EntityId
 import org.cdb.homunculus.models.identifiers.Identifier
@@ -22,6 +23,14 @@ interface TagLogic {
 	 * @throws NotFoundException if no [Tag] exists with the specified id.
 	 */
 	suspend fun get(tagId: EntityId): Tag
+
+	/**
+	 * Retrieves multiple [Tag]s by their [Tag.id].
+	 *
+	 * @param ids the ids of the [Tag]s to retrieve. All the ids that do not correspond to an actual tag are ignored.
+	 * @return a [Flow] of [Tag]s.
+	 */
+	fun getByIds(ids: Set<EntityId>): Flow<Tag>
 
 	/**
 	 * Retrieves all the [Tag]s in the database.

--- a/src/main/kotlin/org/cdb/homunculus/logic/impl/BoxLogicImpl.kt
+++ b/src/main/kotlin/org/cdb/homunculus/logic/impl/BoxLogicImpl.kt
@@ -1,7 +1,6 @@
 package org.cdb.homunculus.logic.impl
 
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filter
 import org.cdb.homunculus.dao.BoxDao
 import org.cdb.homunculus.exceptions.NotFoundException
 import org.cdb.homunculus.logic.BoxLogic
@@ -22,6 +21,7 @@ class BoxLogicImpl(
 	): Identifier {
 		val boxWithLog =
 			box.copy(
+				creationDate = Date(),
 				usageLogs =
 					sortedSetOf(
 						UsageLog(
@@ -39,11 +39,13 @@ class BoxLogicImpl(
 
 	override suspend fun get(boxId: EntityId): Box = boxDao.getById(boxId) ?: throw NotFoundException("Box $boxId not found")
 
-	override fun getAll(): Flow<Box> = boxDao.getAll()
+	override fun getAll(): Flow<Box> = boxDao.get()
 
-	override fun getByMaterial(materialId: EntityId): Flow<Box> = boxDao.getByMaterial(materialId)
+	override fun getByMaterial(materialId: EntityId): Flow<Box> = boxDao.getByMaterial(materialId, false)
 
-	override fun getByPosition(shelfId: HierarchicalId): Flow<Box> = boxDao.getByPosition(shelfId).filter { it.deletionDate == null }
+	override fun getByPosition(shelfId: HierarchicalId): Flow<Box> = boxDao.getByPosition(shelfId, false)
+
+	override fun findByBatchNumber(query: String): Flow<Box> = boxDao.getByBatchNumber(query, false)
 
 	override suspend fun delete(id: EntityId): EntityId {
 		val box = boxDao.getById(id) ?: throw NotFoundException("Box $id not found")

--- a/src/main/kotlin/org/cdb/homunculus/logic/impl/TagLogicImpl.kt
+++ b/src/main/kotlin/org/cdb/homunculus/logic/impl/TagLogicImpl.kt
@@ -16,4 +16,6 @@ class TagLogicImpl(
 	override suspend fun get(tagId: EntityId): Tag = tagDao.getById(tagId) ?: throw NotFoundException("Tag $tagId not found")
 
 	override suspend fun getAll(): Flow<Tag> = tagDao.get()
+
+	override fun getByIds(ids: Set<EntityId>): Flow<Tag> = tagDao.getByIds(ids)
 }

--- a/src/main/kotlin/org/cdb/homunculus/models/Box.kt
+++ b/src/main/kotlin/org/cdb/homunculus/models/Box.kt
@@ -20,6 +20,7 @@ data class Box(
 	val batchNumber: String? = null,
 	@Serializable(with = DateSerializer::class) val expirationDate: Date? = null,
 	@Serializable(with = DateSerializer::class) val deletionDate: Date? = null,
+	@Serializable(with = DateSerializer::class) val creationDate: Date? = null,
 	val description: String? = null,
 	@Serializable(with = SortedSetSerializer::class) val usageLogs: SortedSet<UsageLog> = sortedSetOf(),
 ) : StoredEntity

--- a/src/main/kotlin/org/cdb/homunculus/models/Material.kt
+++ b/src/main/kotlin/org/cdb/homunculus/models/Material.kt
@@ -19,5 +19,6 @@ data class Material(
 	val tags: Set<EntityId> = emptySet(),
 	val noteList: List<Note> = emptyList(),
 	val normalizedName: String? = null,
+	@Serializable(with = DateSerializer::class) val creationDate: Date? = null,
 	@Serializable(with = DateSerializer::class) val deletionDate: Date? = null,
 ) : StoredEntity


### PR DESCRIPTION
## New features
- Added an endpoint to search `Material`s by fuzzy name, tag, brand, and reference code.
- Added an endpoint to get `Material`s by ids.
- Added an endpoint to get the latest created `Material`s
- Added an endpoint to get `Box`es by batch number.
- Added an endpoint to get `Tag`s by ids.
- Added `creationDate` to `Box` and `Material` models.