### PR TITLE
Fixed Sunday Krontab index

### DIFF
--- a/src/main/kotlin/org/cdb/homunculus/models/embed/WeekDay.kt
+++ b/src/main/kotlin/org/cdb/homunculus/models/embed/WeekDay.kt
@@ -10,5 +10,5 @@ enum class WeekDay(val index: Int) {
 	THURSDAY(4),
 	FRIDAY(5),
 	SATURDAY(6),
-	SUNDAY(7),
+	SUNDAY(0),
 }


### PR DESCRIPTION
## Fixes
- In krontab, Sunday is the 0th day.